### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='scibiomart',
               'scibiomart = scibiomart.__main__:main'
           ]
       },
-      install_requires=['pandas', 'numpy', 'sciutil'],
+      install_requires=['pandas', 'numpy', 'sciutil', 'xmltodict'],
       python_requires='>=3.6',
       data_files=[("", ["LICENSE"])]
       )


### PR DESCRIPTION
Adding xmltodict, which caused an error when installing scibiomart into an Ubuntu 18.04 (bionic-beaver ubuntu:bionic-20200219@sha256:0925d086715714114c1988f7c947db94064fd385e171a63c07730f1fa014e6f9) container derived from https://github.com/jupyter/docker-stacks

You may want to check this.